### PR TITLE
Add dbt_project_dir option

### DIFF
--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -107,6 +107,7 @@ class DefaultEventHandler(AnalyzerEventHandler):
 class DbtProjectAnalyzer(object):
     def __init__(self, url: str,
                  api_token: str = None,
+                 dbt_project_path: str = None,
                  project_name: str = None,
                  upload: bool = False,
                  share: bool = False):
@@ -132,7 +133,7 @@ class DbtProjectAnalyzer(object):
         self.project_path = None
 
         # Dbt
-        self.dbt_project_path = None
+        self.dbt_project_path = dbt_project_path
 
         # Control
         self.upload = upload
@@ -176,7 +177,10 @@ class DbtProjectAnalyzer(object):
         # Clone git repo
         self.event_handler.handle_run_progress('Cloning Git Repository', progress=1)
         self.git_repo, self.project_path = clone_github_repo(self.repository)
-        self.dbt_project_path = find_dbt_project(self.project_path)
+        if self.dbt_project_path is None:
+            self.dbt_project_path = find_dbt_project(self.project_path)
+        else:
+            self.dbt_project_path = os.path.join(self.project_path, self.dbt_project_path)
 
         if self.analyze_type == AnalysisType.PULL_REQUEST:
             self.base_branch = self.pull_request.base.ref

--- a/core/cli.py
+++ b/core/cli.py
@@ -14,6 +14,7 @@ from core.utils import RunCommandException
 @click.option('--upload-token', default=None, help='PipeRider Cloud API Token', required=False)
 @click.option('--share/--no-share', default=False, help='Share the report to PipeRider Cloud', required=False)
 @click.option('--debug/--no-debug', default=False, help='Enable debug mode', required=False)
+@click.option('--dbt-project-dir', default=None, help='Which directory to look in for the dbt_project.yml file', required=False)
 @click.pass_context
 def cli(ctx: click.Context, github_url: str, **kwargs):
     upload = kwargs.get('upload', False)
@@ -21,6 +22,7 @@ def cli(ctx: click.Context, github_url: str, **kwargs):
     upload_token = kwargs.get('upload_token') or os.getenv('PIPERIDER_CLOUD_PROJECT', None)
     share = kwargs.get('share', False)
     core.config.DEBUG = kwargs.get('debug', False)
+    dbt_project_dir = kwargs.get('dbt_project_dir', None)
 
     if upload and (upload_project is None or upload_token is None):
         click.echo('Please specify --upload-project and --upload-token when using --upload option')
@@ -29,6 +31,7 @@ def cli(ctx: click.Context, github_url: str, **kwargs):
 
     try:
         analyzer = DbtProjectAnalyzer(github_url,
+                                      dbt_project_path=dbt_project_dir,
                                       upload=upload,
                                       share=share,
                                       project_name=upload_project,


### PR DESCRIPTION
Support `dbt-project-dir` option.
If the repository contains multiple dbt project, users can specify which directory to look in for the `dbt_project.yml`

Example:
```
dbt-project-visualizer \
  --dbt-project-dir transform/mattermost-analytics \
  https://github.com/mattermost/mattermost-data-warehouse/pull/1339
```