### PR TITLE
[Feature] support multiple dbt-projects in a github repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,5 @@ results/
 ### SAM+config Patch ###
 # SAM config - exclude this file if sharing publicly
 samconfig.toml
+
+.idea

--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -2,7 +2,7 @@ import os
 import re
 import tempfile
 from abc import ABCMeta, abstractmethod
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from github import Github
 from github.Auth import Token
@@ -54,6 +54,16 @@ class AnalyzerResult(object):
     def report(self):
         path = self.path if os.path.isabs(self.path) else os.path.abspath(self.path)
         return self.url or path
+
+
+class JobArtifact(object):
+    dbt_project_path: str
+    result: AnalyzerResult | None = None
+    base_result: AnalyzerResult | None = None  # Used for PR
+    head_result: AnalyzerResult | None = None  # Used for PR
+
+    def __init__(self, dbt_project_path: str):
+        self.dbt_project_path = dbt_project_path
 
 
 def _output_result_path(*args):
@@ -170,6 +180,7 @@ class DbtProjectAnalyzer(object):
         if self.dbt_project_path:
             self.dbt_project_paths = [self.dbt_project_path]
 
+        # Jobs
         def job_iterator():
             for job in self.dbt_project_paths:
                 print(f"setup dbt_project_path to {job}")
@@ -183,6 +194,7 @@ class DbtProjectAnalyzer(object):
                 yield callback
 
         self.jobs = job_iterator()
+        self.jobs_artifact: List[JobArtifact] = []
 
         # Control
         self.upload = upload
@@ -191,9 +203,9 @@ class DbtProjectAnalyzer(object):
         self.api_token = api_token
 
         # Analyze Results
-        self.result: AnalyzerResult | None = None
-        self.base_result: AnalyzerResult | None = None  # Used for PR
-        self.head_result: AnalyzerResult | None = None  # Used for PR
+        # self.result: AnalyzerResult | None = None
+        # self.base_result: AnalyzerResult | None = None  # Used for PR
+        # self.head_result: AnalyzerResult | None = None  # Used for PR
 
     def set_event_handler(self, event_handler: AnalyzerEventHandler):
         if event_handler and isinstance(event_handler, AnalyzerEventHandler):
@@ -312,40 +324,48 @@ class DbtProjectAnalyzer(object):
         return report_path, report_url
 
     def summary(self):
-        if self.analyze_type == AnalysisType.PULL_REQUEST:
-            summary, panel_width = self.summary_pull_request()
-        elif self.analyze_type == AnalysisType.REPOSITORY:
-            summary, panel_width = self.summary_repository()
-        else:
-            raise Exception(f"Unknown analyze type: {self.analyze_type}")
+        total = len(self.jobs_artifact)
+        idx = 0
+        for job_artifact in self.jobs_artifact:
+            if len(self.jobs_artifact) > 1:
+                idx += 1
+                console.rule(f"DBT Project '{job_artifact.dbt_project_path}/dbt_project.yml' [{idx}/{total}]")
+            if self.analyze_type == AnalysisType.PULL_REQUEST:
+                summary, panel_width = self.summary_pull_request(job_artifact.base_result,
+                                                                 job_artifact.head_result,
+                                                                 job_artifact.result)
+            elif self.analyze_type == AnalysisType.REPOSITORY:
+                summary, panel_width = self.summary_repository(job_artifact.result)
+            else:
+                raise Exception(f"Unknown analyze type: {self.analyze_type}")
 
-        from rich.markdown import Markdown
-        from rich.panel import Panel
+            from rich.markdown import Markdown
+            from rich.panel import Panel
 
-        panel = Panel(Markdown(summary), width=panel_width, expand=False)
-        console.print(panel)
-        if os.getenv('GITHUB_ACTIONS') == 'true':
-            with open('summary.md', 'w') as f:
-                f.write(summary)
+            panel = Panel(Markdown(summary), width=panel_width, expand=False)
+            console.print(panel)
+            if os.getenv('GITHUB_ACTIONS') == 'true':
+                with open('summary.md', 'w') as f:
+                    f.write(summary)
 
-    def summary_repository(self):
+    def summary_repository(self, result: AnalyzerResult):
         # Repo summary
-        panel_width = len(self.result.report) + 8
+        panel_width = len(result.report) + 8
         content = f'''
 # Dbt Project '{self.repository.full_name}' Repository Summary
 - Repo URL: {self.repository.html_url}
 
 ## Default Branch - {self.repository.default_branch}
-- Report: {self.result.report}
+- Report: {result.report}
 '''
 
         return content, panel_width
 
-    def summary_pull_request(self):
+    def summary_pull_request(self, base, head, compare):
         # PR summary
-        base_report = self.base_result.report
-        head_report = self.head_result.report
-        compare_report = self.result.report
+        base_report = base.report
+        head_report = head.report
+        compare_report = compare.report
         panel_width = max(len(base_report), len(head_report), len(compare_report)) + 8
         content = f'''
 # Dbt Project '{self.repository.full_name}' Pull Request #{self.pull_request.number} Summary
@@ -355,7 +375,7 @@ class DbtProjectAnalyzer(object):
 - PR Status: {self.pull_request.state}
 
 ## Pull Request - {self.pull_request.base.ref} <- {self.pull_request.head.ref} #{self.pull_request.number}
-- Compare Report: {self.result.report}
+- Compare Report: {compare_report}
 
 ### Base Branch - {self.pull_request.base.ref} {self.pull_request.base.sha[0:7]}
 - Report: {base_report}
@@ -387,12 +407,15 @@ class DbtProjectAnalyzer(object):
             raise Exception(f"Unknown analyze type: {self.analyze_type}")
 
     def analyze_repository(self):
+        artifact = JobArtifact(os.path.relpath(self.dbt_project_path, self.project_path))
         branch = self.repository.default_branch
         self.event_handler.handle_run_progress(f"Process Default Branch: '{branch}'", progress=10)
         report_path, report_url = self.generate_piperider_report(branch)
-        self.result = AnalyzerResult(branch, report_path, report_url)
+        artifact.result = AnalyzerResult(branch, report_path, report_url)
+        self.jobs_artifact.append(artifact)
 
     def analyze_pull_request(self):
+        artifact = JobArtifact(os.path.relpath(self.dbt_project_path, self.project_path))
         base_branch = self.pull_request.base.ref
         base_sha = self.pull_request.base.sha
         head_branch = self.pull_request.head.ref
@@ -406,7 +429,7 @@ class DbtProjectAnalyzer(object):
             'PIPERIDER_GIT_SHA': base_sha,
         }):
             report_path, report_url = self.generate_piperider_report(base_sha)
-            self.base_result = AnalyzerResult(base_branch, report_path, report_url)
+            artifact.base_result = AnalyzerResult(base_branch, report_path, report_url)
 
         self.event_handler.handle_run_progress(f"Process Head Branch: '{head_branch}' {head_sha[0:7]}", progress=60)
         with EnvContext({
@@ -414,7 +437,7 @@ class DbtProjectAnalyzer(object):
             'PIPERIDER_GIT_SHA': head_sha,
         }):
             report_path, report_url = self.generate_piperider_report(head_sha)
-            self.head_result = AnalyzerResult(head_branch, report_path, report_url)
+            artifact.head_result = AnalyzerResult(head_branch, report_path, report_url)
 
         self.event_handler.handle_run_progress(f"Compare '{base_branch}'...'{head_branch}'", progress=90)
         with EnvContext({
@@ -423,7 +446,8 @@ class DbtProjectAnalyzer(object):
             'GITHUB_PR_TITLE': self.pull_request.title
         }):
             report_path, report_url = self.compare_piperider_reports()
-            self.result = AnalyzerResult(f'{head_branch}_vs_{base_branch}', report_path, report_url)
+            artifact.result = AnalyzerResult(f'{head_branch}_vs_{base_branch}', report_path, report_url)
+        self.jobs_artifact.append(artifact)
 
     def ping(self):
         return "pong 🏓 🏓 🏓 \n Github URL: " + self.url

--- a/core/cli.py
+++ b/core/cli.py
@@ -36,7 +36,9 @@ def cli(ctx: click.Context, github_url: str, **kwargs):
                                       share=share,
                                       project_name=upload_project,
                                       api_token=upload_token)
-        analyzer.exec()
+        analyzer.pre_exec()
+        while not analyzer.done():
+            analyzer.exec()
         analyzer.summary()
     except RunCommandException as e:
         click.echo(f'Failed to exec the project: {e.msg}')

--- a/core/cli.py
+++ b/core/cli.py
@@ -14,7 +14,8 @@ from core.utils import RunCommandException
 @click.option('--upload-token', default=None, help='PipeRider Cloud API Token', required=False)
 @click.option('--share/--no-share', default=False, help='Share the report to PipeRider Cloud', required=False)
 @click.option('--debug/--no-debug', default=False, help='Enable debug mode', required=False)
-@click.option('--dbt-project-dir', default=None, help='Which directory to look in for the dbt_project.yml file', required=False)
+@click.option('--dbt-project-dir', default=None, help='Which directory to look in for the dbt_project.yml file',
+              required=False)
 @click.pass_context
 def cli(ctx: click.Context, github_url: str, **kwargs):
     upload = kwargs.get('upload', False)
@@ -37,8 +38,9 @@ def cli(ctx: click.Context, github_url: str, **kwargs):
                                       project_name=upload_project,
                                       api_token=upload_token)
         analyzer.pre_exec()
-        while not analyzer.done():
-            analyzer.exec()
+        for job_func in analyzer.jobs:
+            job_func()
+
         analyzer.summary()
     except RunCommandException as e:
         click.echo(f'Failed to exec the project: {e.msg}')

--- a/core/dbt.py
+++ b/core/dbt.py
@@ -5,18 +5,16 @@ from ruamel import yaml
 from core.utils import console, run_command, RunCommandException
 
 
-def find_dbt_project(project_path: str):
+def find_dbt_projects(project_path: str):
     dbt_project_file = 'dbt_project.yml'
+    dbt_projects = []
 
     dbt_project_dir = None
     for root, directory, files in os.walk(project_path):
         if dbt_project_file in files:
-            dbt_project_dir = root
+            dbt_projects.append(root)
 
-    if dbt_project_dir is None:
-        return None
-
-    return dbt_project_dir
+    return dbt_projects
 
 
 def patch_dbt_profiles(dbt_project_dir: str):

--- a/core/dbt.py
+++ b/core/dbt.py
@@ -14,7 +14,7 @@ def find_dbt_projects(project_path: str):
         if dbt_project_file in files:
             dbt_projects.append(root)
 
-    return dbt_projects
+    return sorted(dbt_projects)
 
 
 def patch_dbt_profiles(dbt_project_dir: str):

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -154,8 +154,8 @@ def analyze(payload, event_handler: AnalyzerEventHandler = None):
         # load github project and checking how many dbt-projects
         analyzer.pre_exec()
 
-        while not analyzer.done():
-            analyzer.exec()
+        for job_func in analyzer.jobs:
+            job_func()
 
         status = 'completed'
     except BaseException as e:

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -170,8 +170,8 @@ def analyze(payload, event_handler: AnalyzerEventHandler = None):
     finally:
         analyzer.handle_run_end()
 
-    if analyzer.result:
-        report_url = analyzer.result.report
+    if analyzer.jobs_artifact:
+        report_url = ','.join([artifact.result.report for artifact in analyzer.jobs_artifact])
     else:
         report_url = None
         status = 'failed'

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -149,7 +149,14 @@ def analyze(payload, event_handler: AnalyzerEventHandler = None):
     reason = ''
     console_output = None
     try:
-        analyzer.exec()
+        analyzer.handle_run_start()
+
+        # load github project and checking how many dbt-projects
+        analyzer.pre_exec()
+
+        while not analyzer.done():
+            analyzer.exec()
+
         status = 'completed'
     except BaseException as e:
         if isinstance(e, RunCommandException):
@@ -160,6 +167,8 @@ def analyze(payload, event_handler: AnalyzerEventHandler = None):
             print(f'Error: {str(e)}')
             reason = str(e)
         status = 'failed'
+    finally:
+        analyzer.handle_run_end()
 
     if analyzer.result:
         report_url = analyzer.result.report


### PR DESCRIPTION
* scan all dbt-projects in a github repo
* make sure the scanning order consistent by sorting the project path
* decorate the job progress in the messages if it was needed (check the sample image)

<img width="1881" alt="image" src="https://github.com/InfuseAI/dbt-project-pull-request-visualizer/assets/193223/b8ae96d2-9dbc-40ab-bf94-9de57a43417a">
